### PR TITLE
feat(6): Velero backup and recovery support

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -41,6 +41,7 @@ ignore: |
   roles/infrastructure/templates/cronjob-postgres-backup-monthly.yaml.j2
   roles/infrastructure/templates/pvc-postgres.yaml.j2
   roles/infrastructure/templates/pvc-postgres-backup.yaml.j2
+  roles/infrastructure/templates/pvc-postgres-velero.yaml.j2
   roles/infrastructure/templates/serviceaccount-im-infra.yaml.j2
   roles/infrastructure/templates/statefulset-keycloak.yaml.j2
   roles/infrastructure/templates/statefulset-postgres.yaml.j2

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -148,7 +148,9 @@ The ``backup.velero.io/backup-volumes`` annotation therefore hands Velero the
 dump volume, and the hooks keep that volume's dump up to date: -
 
 *   The **pre-backup** hook removes any existing dump and then writes a new
-    one with ``pg_dumpall``
+    one with ``pg_dumpall --clean --if-exists``, so that replaying it drops
+    and re-creates each role and database rather than failing against
+    whatever the recovered database already holds
 *   The **post-restore** hook waits for the recovered database, replays the
     dump into it with ``psql``, and then removes the dump (the next backup
     writes a new one)

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -128,6 +128,34 @@ backup at 7 minutes past each hour, keeping the last 24 backups.
 For more details refer to the documentation in ``backup.py`` in our
 `Backup and Recovery`_ repository.
 
+PostgreSQL Velero Backups
+=========================
+
+Optionally, and in addition to the backup strategy above, the database can be
+prepared for backup and recovery with `Velero`_. Set ``pg_velero_state`` to
+``present`` and the ``infrastructure`` Role will: -
+
+*   Create a **Persistent Volume Claim** (``pg-velero`` by default) for a
+    ``pg_dumpall`` file, mounted at ``/velero`` in the database container
+*   Annotate the database **Pod** with Velero *backup* and *restore* hooks
+
+Velero is expected to be installed on the cluster - it is not deployed by
+this repository.
+
+We back up a database dump rather than the database's binary files because
+a copy of the binary files does not necessarily restore to a viable database.
+The ``backup.velero.io/backup-volumes`` annotation therefore hands Velero the
+dump volume, and the hooks keep that volume's dump up to date: -
+
+*   The **pre-backup** hook removes any existing dump and then writes a new
+    one with ``pg_dumpall``
+*   The **post-restore** hook waits for the recovered database, replays the
+    dump into it with ``psql``, and then removes the dump (the next backup
+    writes a new one)
+
+The ``pg_velero_backup_timeout`` and ``pg_velero_restore_timeout`` variables
+limit how long Velero gives each hook - increase them for large databases.
+
 Keycloak
 ========
 
@@ -173,3 +201,4 @@ For more details refer to the documentation in ``recovery.py`` in our
 .. _Kubernetes Cert Manager: https://github.com/jetstack/cert-manager
 .. _Rancher: https://rancher.com
 .. _RKE: https://rancher.com/docs/rke/latest/en/
+.. _Velero: https://velero.io

--- a/roles/infrastructure/defaults/main.yaml
+++ b/roles/infrastructure/defaults/main.yaml
@@ -105,6 +105,32 @@ pg_bu_weekly_history: 0
 # If you use monthly you must also use weekly.
 pg_bu_monthly_history: 0
 
+# Database (Velero backup and recovery) ---------------------------------------
+
+# Deploy Velero backup and recovery support?
+# One of 'present' or 'absent'.
+#
+# When 'present' a dedicated volume is created for a 'pg_dumpall' file and
+# Velero backup and restore hook annotations are added to the database Pod.
+# Velero backs up the dump (not the database's binary files, which may not
+# restore to a viable database) and, on restore, replays it into the
+# recovered database.
+#
+# Velero is expected to be installed on the cluster.
+# It is not deployed by this repository.
+pg_velero_state: absent
+# The name of the volume claim used for the 'pg_dumpall' file.
+pg_velero_volume_name: pg-velero
+# The Velero dump volume size (Gi).
+pg_velero_vol_size_g: 10
+# The Velero dump volume StorageClass.
+# A blank class implies the cluster default.
+pg_velero_vol_storageclass: " "
+# How long Velero is given to run the pre-backup ('pg_dumpall') hook
+# and the post-restore ('psql') hook. Increase these for large databases.
+pg_velero_backup_timeout: 30m
+pg_velero_restore_timeout: 30m
+
 # Keycloak --------------------------------------------------------------------
 
 # Deploy (or un-deploy)?

--- a/roles/infrastructure/tasks/deploy.yaml
+++ b/roles/infrastructure/tasks/deploy.yaml
@@ -189,6 +189,48 @@
     retries: "{{ (bind_timeout | int / 5) | int }}"
     when: wait_for_bind | bool
 
+  # The Velero dump volume.
+  # Only created if Velero backup and recovery support is enabled,
+  # and it must exist before the StatefulSet (which mounts it) is deployed.
+
+  - name: Velero dump volume
+    when: pg_velero_state | string == 'present'
+    block:
+
+    - name: Get {{ pg_velero_vol_storageclass }} StorageClass (Velero)
+      kubernetes.core.k8s_info:
+        kind: StorageClass
+        name: "{{ pg_velero_vol_storageclass }}"
+      register: velero_sc_result
+      when: pg_velero_vol_storageclass != " "
+
+    - name: Assert {{ pg_velero_vol_storageclass }} StorageClass (Velero)
+      ansible.builtin.assert:
+        that: velero_sc_result.resources | length == 1
+        fail_msg: The {{ pg_velero_vol_storageclass }} StorageClass must be available on the cluster
+      when: pg_velero_vol_storageclass != " "
+
+    - name: Create postgres Velero volume claim ({{ pg_velero_vol_storageclass }})
+      kubernetes.core.k8s:
+        definition: "{{ lookup('template', 'pvc-postgres-velero.yaml.j2') }}"
+        wait: yes
+        wait_timeout: "{{ wait_timeout }}"
+
+    - name: Wait for postgres Velero volume claim to bind
+      kubernetes.core.k8s_info:
+        kind: PersistentVolumeClaim
+        name: "{{ pg_velero_volume_name }}"
+        namespace: "{{ infra_namespace }}"
+      register: pg_velero_pvc_result
+      until: >-
+        pg_velero_pvc_result.resources | length > 0
+        and pg_velero_pvc_result.resources[0].status is defined
+        and pg_velero_pvc_result.resources[0].status.phase is defined
+        and pg_velero_pvc_result.resources[0].status.phase == 'Bound'
+      delay: 5
+      retries: "{{ (bind_timeout | int / 5) | int }}"
+      when: wait_for_bind | bool
+
   - name: Postgres
     kubernetes.core.k8s:
       definition: "{{ lookup('template', item) }}"

--- a/roles/infrastructure/templates/pvc-postgres-velero.yaml.j2
+++ b/roles/infrastructure/templates/pvc-postgres-velero.yaml.j2
@@ -1,0 +1,15 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ pg_velero_volume_name }}
+  namespace: {{ infra_namespace }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+{% if pg_velero_vol_storageclass != ' ' %}
+  storageClassName: '{{ pg_velero_vol_storageclass }}'
+{% endif %}
+  resources:
+    requests:
+      storage: '{{ pg_velero_vol_size_g }}Gi'

--- a/roles/infrastructure/templates/statefulset-postgres.yaml.j2
+++ b/roles/infrastructure/templates/statefulset-postgres.yaml.j2
@@ -15,6 +15,29 @@ spec:
       name: database
       labels:
         app: database
+{% if pg_velero_state | string == 'present' %}
+      # Velero backup and recovery hooks.
+      #
+      # Backing up the database's binary files does not guarantee a viable
+      # database so, instead, we back up a 'pg_dumpall' file written to a
+      # dedicated volume ('{{ pg_velero_pod_volume_name }}'), which is the
+      # only volume we hand to Velero. On restore the dump is replayed into
+      # the recovered database.
+      annotations:
+        backup.velero.io/backup-volumes: {{ pg_velero_pod_volume_name }}
+        # Before the backup - replace any existing dump with a fresh one.
+        pre.hook.backup.velero.io/container: database
+        pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "rm -f {{ pg_velero_dump_file }} && PGPASSWORD=\"$POSTGRES_PASSWORD\" pg_dumpall --host=127.0.0.1 --username=\"$POSTGRES_USER\" --file={{ pg_velero_dump_file }}"]'
+        pre.hook.backup.velero.io/on-error: Fail
+        pre.hook.backup.velero.io/timeout: {{ pg_velero_backup_timeout }}
+        # After the restore - wait for the database, replay the dump and then
+        # remove it (the next backup writes a new one).
+        post.hook.restore.velero.io/container: database
+        post.hook.restore.velero.io/command: '["/bin/bash", "-c", "until pg_isready --host=127.0.0.1 --port=5432 --username=\"$POSTGRES_USER\" --quiet; do sleep 5; done; PGPASSWORD=\"$POSTGRES_PASSWORD\" psql --host=127.0.0.1 --username=\"$POSTGRES_USER\" --file={{ pg_velero_dump_file }} && rm -f {{ pg_velero_dump_file }}"]'
+        post.hook.restore.velero.io/on-error: Fail
+        post.hook.restore.velero.io/exec-timeout: {{ pg_velero_restore_timeout }}
+        post.hook.restore.velero.io/wait-timeout: {{ pg_velero_restore_timeout }}
+{% endif %}
     spec:
 {% if infra_priority_class %}
       priorityClassName: {{ infra_priority_class }}
@@ -99,6 +122,11 @@ spec:
         # Persistent volume for data
         - mountPath: /var/lib/postgresql/data
           name: postgres-pvc
+{% if pg_velero_state | string == 'present' %}
+        # Persistent volume for the Velero 'pg_dumpall' file
+        - mountPath: {{ pg_velero_mount_path }}
+          name: {{ pg_velero_pod_volume_name }}
+{% endif %}
         env:
         # PGDATA - the location of persisted database files.
         # Normally a sub-directory of '/var/lib/postgresql/data'.
@@ -141,3 +169,8 @@ spec:
       - name: postgres-pvc
         persistentVolumeClaim:
           claimName: {{ pg_volume_name }}
+{% if pg_velero_state | string == 'present' %}
+      - name: {{ pg_velero_pod_volume_name }}
+        persistentVolumeClaim:
+          claimName: {{ pg_velero_volume_name }}
+{% endif %}

--- a/roles/infrastructure/templates/statefulset-postgres.yaml.j2
+++ b/roles/infrastructure/templates/statefulset-postgres.yaml.j2
@@ -26,8 +26,15 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: {{ pg_velero_pod_volume_name }}
         # Before the backup - replace any existing dump with a fresh one.
+        #
+        # The dump is written with '--clean --if-exists' so that it drops and
+        # re-creates each role and database as it is replayed. Without this a
+        # recovered database that is not empty (Velero may also restore the
+        # data volume, from a CSI snapshot) keeps its stale content - every
+        # statement in the dump fails with 'already exists' and the restore
+        # hook still 'succeeds'.
         pre.hook.backup.velero.io/container: database
-        pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "rm -f {{ pg_velero_dump_file }} && PGPASSWORD=\"$POSTGRES_PASSWORD\" pg_dumpall --host=127.0.0.1 --username=\"$POSTGRES_USER\" --file={{ pg_velero_dump_file }}"]'
+        pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "rm -f {{ pg_velero_dump_file }} && PGPASSWORD=\"$POSTGRES_PASSWORD\" pg_dumpall --host=127.0.0.1 --username=\"$POSTGRES_USER\" --clean --if-exists --file={{ pg_velero_dump_file }}"]'
         pre.hook.backup.velero.io/on-error: Fail
         pre.hook.backup.velero.io/timeout: {{ pg_velero_backup_timeout }}
         # After the restore - wait for the database, replay the dump and then

--- a/roles/infrastructure/vars/main.yaml
+++ b/roles/infrastructure/vars/main.yaml
@@ -42,6 +42,13 @@ pg_cpu_limit: 1000m
 pg_mem_request: 1Gi
 pg_mem_limit: 1Gi
 
+# The name of the database Pod's Velero dump volume, where it is mounted,
+# and the file the 'pg_dumpall' is written to. The Velero backup and restore
+# hooks (annotations on the database Pod) read and write this file.
+pg_velero_pod_volume_name: postgres-velero
+pg_velero_mount_path: /velero
+pg_velero_dump_file: "{{ pg_velero_mount_path }}/dumpall.sql"
+
 # Keycloak --------------------------------------------------------------------
 
 # The Keycloak image version and image registry


### PR DESCRIPTION
Fixes #6

Adds optional [Velero](https://velero.io) backup and recovery support to the
infrastructure database. Off by default (`pg_velero_state: absent`) and Velero
itself is expected to be installed on the cluster - it is not deployed here.

Because a copy of the database's binary files does not guarantee a viable
database, we back up a `pg_dumpall` file instead, on a volume of its own.

### What's new

1. **A new backup volume** - `pvc-postgres-velero.yaml.j2` creates the
   `pg-velero` PVC, mounted at `/velero` in the `database` container
   (`pg_velero_vol_size_g`, `pg_velero_vol_storageclass`).
2. **Pre-backup hooks** - remove any existing `/velero/dumpall.sql` and then
   write a fresh one with `pg_dumpall`.
3. **Recovery hooks** - a post-restore hook waits for the recovered database
   (`pg_isready`), replays the dump with `psql`, and then removes it (the next
   backup writes a new one).

The Pod is also annotated with `backup.velero.io/backup-volumes: postgres-velero`
so that Velero's file-system backup takes the dump volume, and not the
database's data volume.

### New variables

| Variable | Default | Purpose |
|---|---|---|
| `pg_velero_state` | `absent` | Deploy Velero support? |
| `pg_velero_volume_name` | `pg-velero` | The dump volume claim name |
| `pg_velero_vol_size_g` | `10` | The dump volume size (Gi) |
| `pg_velero_vol_storageclass` | `" "` | The dump volume StorageClass |
| `pg_velero_backup_timeout` | `30m` | Time allowed for the `pg_dumpall` hook |
| `pg_velero_restore_timeout` | `30m` | Time allowed for the `psql` hook |

With `pg_velero_state: absent` the rendered StatefulSet is byte-for-byte
unchanged.

### Verification

Tests are not required in this repository (per the issue), so this was checked
by rendering the templates with both `pg_velero_state` values and confirming
the resulting YAML - and the JSON hook commands within it - parse and carry the
expected volumes, mounts and annotations. `yamllint` (both CI invocations),
`pre-commit run --all-files` and the Sphinx doc build all pass.

`doc/architecture.rst` gains a *PostgreSQL Velero Backups* section.
